### PR TITLE
 REVERT: Back to original CMS env vars that were working

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,6 @@ jobs:
           CMS_GRAPHQL_ENDPOINT: ${{ secrets.CMS_GRAPHQL_ENDPOINT }}
           CMS_ACCESS_TOKEN: ${{ secrets.CMS_ACCESS_TOKEN }}
           CMS_PREVIEW_ACCESS_TOKEN: ${{ secrets.CMS_PREVIEW_ACCESS_TOKEN }}
-          NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: ${{ secrets.NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT }}
-          NEXT_PUBLIC_CMS_ACCESS_TOKEN: ${{ secrets.NEXT_PUBLIC_CMS_ACCESS_TOKEN }}
         run: |
           node -v
           npm -v

--- a/src/utils/apollo_client.ts
+++ b/src/utils/apollo_client.ts
@@ -1,12 +1,9 @@
 import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 
-// Get environment variables (works with NEXT_PUBLIC prefix for client-side)
-const endpoint =
-  process.env.NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT ||
-  process.env.CMS_GRAPHQL_ENDPOINT;
-const token =
-  process.env.NEXT_PUBLIC_CMS_ACCESS_TOKEN || process.env.CMS_ACCESS_TOKEN;
+// Get environment variables
+const endpoint = process.env.CMS_GRAPHQL_ENDPOINT;
+const token = process.env.CMS_ACCESS_TOKEN;
 
 // Simple HTTP link
 const httpLink = createHttpLink({

--- a/src/utils/apollo_client_simple.ts
+++ b/src/utils/apollo_client_simple.ts
@@ -1,12 +1,9 @@
 import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 
-// Get environment variables (works with NEXT_PUBLIC prefix for client-side)
-const endpoint =
-  process.env.NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT ||
-  process.env.CMS_GRAPHQL_ENDPOINT;
-const token =
-  process.env.NEXT_PUBLIC_CMS_ACCESS_TOKEN || process.env.CMS_ACCESS_TOKEN;
+// Get environment variables
+const endpoint = process.env.CMS_GRAPHQL_ENDPOINT;
+const token = process.env.CMS_ACCESS_TOKEN;
 
 // Simple HTTP link
 const httpLink = createHttpLink({


### PR DESCRIPTION
- Remove NEXT_PUBLIC_ prefixed variables from Apollo Client
- Revert to original CMS_GRAPHQL_ENDPOINT and CMS_ACCESS_TOKEN
- Remove NEXT_PUBLIC_ vars from GitHub Actions
- This restores the working configuration before the deployment issues