### PR TITLE
 FINAL FIX: Use NEXT_PUBLIC_ env vars for client-side Apollo

### DIFF
--- a/src/utils/apollo_client.ts
+++ b/src/utils/apollo_client.ts
@@ -1,9 +1,9 @@
 import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 
-// Get environment variables
-const endpoint = process.env.CMS_GRAPHQL_ENDPOINT;
-const token = process.env.CMS_ACCESS_TOKEN;
+// Get environment variables - NEXT_PUBLIC_ required for browser access
+const endpoint = process.env.NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT;
+const token = process.env.NEXT_PUBLIC_CMS_ACCESS_TOKEN;
 
 // Simple HTTP link
 const httpLink = createHttpLink({

--- a/src/utils/apollo_client_simple.ts
+++ b/src/utils/apollo_client_simple.ts
@@ -1,9 +1,9 @@
 import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 
-// Get environment variables
-const endpoint = process.env.CMS_GRAPHQL_ENDPOINT;
-const token = process.env.CMS_ACCESS_TOKEN;
+// Get environment variables - NEXT_PUBLIC_ required for browser access
+const endpoint = process.env.NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT;
+const token = process.env.NEXT_PUBLIC_CMS_ACCESS_TOKEN;
 
 // Simple HTTP link
 const httpLink = createHttpLink({


### PR DESCRIPTION
- Apollo Client needs NEXT_PUBLIC_ prefixed vars to work in browser
- Server-side vars (CMS_*) are not available in browser code
- This fixes the 405 error where Apollo tried to call /graphql on our domain
- Now it will correctly call graphql.contentful.com from the browser